### PR TITLE
Update ways to use Xfce and mesa3d

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ that builds risc-v based Linux kernel suitable for running on the QEMU emulator.
     * Similar to make run-fedora, expect running qemu with the virtio-gpu device and friends
     * Use `dnf install xclock twm xterm` to pull down X server packages
     * `startx` starts screen in graphics mode.
+    * `dnf install @xfce-desktop-environment --skip-broken` to install Xfce. Use `xinit /usr/bin/xfce4-session` to launch the Xfce desktop.
+    * Running OpenGL program will cause LLVM error. Recompiling mesa3d with Xlib driver is a fix. Use the fedora/mesa.sh script to compile and install mesa3d.
 
 1. Run Debian Linux 
     `riscv-builder$ make run-debian`

--- a/fedora/Makefile
+++ b/fedora/Makefile
@@ -43,7 +43,7 @@ run:  | $(IMAGES)
 run-gui:  | $(IMAGES)
 	( \
 	 cd ../bin; \
-	 ./qemu-system-riscv64 -M virt  -smp 2 -m 1G \
+	 ./qemu-system-riscv64 -M virt  -smp 2 -m 4G \
 	 -kernel $(INSTALL-DIR)/fw_payload-uboot-qemu-virt-smode.elf \
 	 -object rng-random,filename=/dev/urandom,id=rng0 \
 	 -device virtio-rng-device,rng=rng0 \

--- a/fedora/mesa.sh
+++ b/fedora/mesa.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+wget https://mesa.freedesktop.org/archive/mesa-20.0.1.tar.xz
+dnf builddep mesa
+tar -xf mesa-20.0.1.tar.xz && cd mesa-20.0.1
+meson --prefix=/usr builddir/ -Dgallium-drivers=virgl -Ddri-drivers= -Dvulkan-drivers= -Dglx=xlib
+ninja -C builddir/ install


### PR DESCRIPTION
1G memory is not sufficient for desktop environment and compiling mesa.
Add instruction to Install Xfce4 desktop.
Recompiling mesa3d to avoid LLVM error.